### PR TITLE
Feature/workspace kill on logout

### DIFF
--- a/dojo_plugin/__init__.py
+++ b/dojo_plugin/__init__.py
@@ -26,6 +26,7 @@ from .pages.workspace import workspace
 from .pages.sensai import sensai
 from .pages.users import users
 from .pages.settings import settings_override
+from .pages.auth import logout_override
 from .pages.discord import discord
 from .pages.course import course
 from .pages.canvas import sync_canvas_user, canvas
@@ -129,6 +130,7 @@ def load(app):
     app.view_functions["views.static_html"] = static_html_override
     app.view_functions["views.settings"] = settings_override
     app.view_functions["challenges.listing"] = dojos_override
+    app.view_functions["auth.logout"] = logout_override
     del app.view_functions["scoreboard.listing"]
     del app.view_functions["users.private"]
     del app.view_functions["users.public"]

--- a/dojo_plugin/api/__init__.py
+++ b/dojo_plugin/api/__init__.py
@@ -10,6 +10,7 @@ from .v1.scoreboard import scoreboard_namespace
 from .v1.ssh_key import ssh_key_namespace
 from .v1.workspace_tokens import workspace_tokens_namespace
 from .v1.workspace import workspace_namespace
+from .v1.challenge_preferences import challenge_preferences_namespace
 
 
 api = Blueprint("pwncollege_api", __name__)
@@ -24,3 +25,4 @@ api_v1.add_namespace(scoreboard_namespace, "/scoreboard")
 api_v1.add_namespace(ssh_key_namespace, "/ssh_key")
 api_v1.add_namespace(workspace_tokens_namespace, "/workspace_tokens")
 api_v1.add_namespace(workspace_namespace, "/workspace")
+api_v1.add_namespace(challenge_preferences_namespace, "/chall_pref")

--- a/dojo_plugin/api/v1/challenge_preferences.py
+++ b/dojo_plugin/api/v1/challenge_preferences.py
@@ -1,0 +1,30 @@
+from flask import request
+from flask_restx import Namespace, Resource
+from CTFd.models import db
+from CTFd.utils.decorators import authed_only
+from CTFd.utils.user import get_current_user
+
+from ...models import UserChallengePreferences
+
+challenge_preferences_namespace = Namespace(
+    "chall_pref", description="Endpoint to manage user preferences relating to challenge behavior"
+)
+
+@challenge_preferences_namespace.route("")
+class ChallengePreferences(Resource):
+    @authed_only
+    def post(self):
+        data = request.get_json()
+        user = get_current_user()
+
+        pref_keys = ["stop_on_logout"]
+        for key in pref_keys:
+            if key not in data:
+                return {"success": False, "error": f"Invalid JSON data - {key} not found!"}, 400
+
+        kwargs = {"user_id": user.id, "stop_on_logout": data.get("stop_on_logout", True)}
+        user_prefs = UserChallengePreferences(**kwargs)
+        db.session.merge(user_prefs)
+        db.session.commit()
+
+        return {"success": True}

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -798,7 +798,7 @@ class UserChallengePreferences(db.Model):
 
     stop_on_logout = db.Column(db.Boolean, default=True)
 
-    __repr__ = columns_repr("user", "stop_on_logout")
+    __repr__ = columns_repr(["user", "stop_on_logout"])
 
 class Belts(Awards):
     __mapper_args__ = {"polymorphic_identity": "belt"}

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -788,6 +788,17 @@ class DiscordUsers(db.Model):
 
     __repr__ = columns_repr(["user", "discord_id"])
 
+class UserChallengePreferences(db.Model):
+    __tablename__ = "user_challenge_preferences"
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+
+    user = db.relationship("Users")
+
+    stop_on_logout = db.Column(db.Boolean, default=True)
+
+    __repr__ = columns_repr("user", "stop_on_logout")
 
 class Belts(Awards):
     __mapper_args__ = {"polymorphic_identity": "belt"}

--- a/dojo_plugin/pages/auth.py
+++ b/dojo_plugin/pages/auth.py
@@ -1,0 +1,12 @@
+from CTFd.utils import user as current_user
+from CTFd.auth import logout
+from ..api.v1.docker import remove_container
+
+def logout_override():
+    if current_user.authed():
+        # Logout must continue even if this fails
+        try:
+            remove_container(current_user)
+        except Exception:
+            pass
+    return logout()

--- a/dojo_plugin/pages/auth.py
+++ b/dojo_plugin/pages/auth.py
@@ -1,12 +1,17 @@
-from CTFd.utils import user
+from CTFd.utils.user import authed, get_current_user
 from CTFd.auth import logout
 from ..api.v1.docker import remove_container
+from ..models import UserChallengePreferences
 
 def logout_override():
-    if user.authed():
+    if authed():
         # Logout must continue even if this fails
         try:
-            remove_container(user.get_current_user())
+            user = get_current_user()
+            chall_prefs = UserChallengePreferences.query.filter_by(user_id=user.id).first()
+            # If no preference, default to stopping container
+            if chall_prefs is None or chall_prefs.stop_on_logout:
+                remove_container(user)
         except Exception:
             pass
     return logout()

--- a/dojo_plugin/pages/auth.py
+++ b/dojo_plugin/pages/auth.py
@@ -1,12 +1,12 @@
-from CTFd.utils import user as current_user
+from CTFd.utils import user
 from CTFd.auth import logout
 from ..api.v1.docker import remove_container
 
 def logout_override():
-    if current_user.authed():
+    if user.authed():
         # Logout must continue even if this fails
         try:
-            remove_container(current_user)
+            remove_container(user.get_current_user())
         except Exception:
             pass
     return logout()

--- a/dojo_plugin/pages/settings.py
+++ b/dojo_plugin/pages/settings.py
@@ -5,7 +5,7 @@ from CTFd.utils.helpers import get_infos, markup
 from CTFd.utils.decorators import authed_only
 from CTFd.utils.user import get_current_user
 
-from ..models import SSHKeys, DiscordUsers
+from ..models import SSHKeys, DiscordUsers, UserChallengePreferences
 from ..config import DISCORD_CLIENT_ID
 from ..utils.discord import get_discord_member, discord_avatar_asset
 
@@ -23,6 +23,11 @@ def settings_override():
                                         .with_entities(DiscordUsers.discord_id).scalar())
 
     prevent_name_change = get_config("prevent_name_change")
+
+    chall_pref = UserChallengePreferences.query.filter_by(user_id=user.id).first()
+
+    if chall_pref is None:
+        chall_pref = UserChallengePreferences(user_id=user.id, stop_on_logout=True)
 
     if get_config("verify_emails") and not user.verified:
         confirm_url = markup(url_for("auth.confirm"))
@@ -44,4 +49,5 @@ def settings_override():
         discord_avatar_asset=discord_avatar_asset,
         prevent_name_change=prevent_name_change,
         infos=infos,
+        chall_pref=chall_pref,
     )

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -105,7 +105,7 @@ $(() => {
     button_fetch_and_show("reset-home", "/pwncollege_api/v1/workspace/reset_home", "POST", {}, "Home directory reset successfully", "Home directory reset canceled", function() {
       return confirm("Are you sure you want to reset your home directory?");
     });
-    form_fetch_and_show("challenge-preference-form", "/pwncollege_api/v1/chall_pref", "POST", "Changes have been saved");
+    form_fetch_and_show("challenge-preference", "/pwncollege_api/v1/chall_pref", "POST", "Changes have been saved");
     $(".copy-button").click((event) => {
         let input = $(event.target).parents(".input-group").children("input")[0];
         input.select();

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -105,6 +105,7 @@ $(() => {
     button_fetch_and_show("reset-home", "/pwncollege_api/v1/workspace/reset_home", "POST", {}, "Home directory reset successfully", "Home directory reset canceled", function() {
       return confirm("Are you sure you want to reset your home directory?");
     });
+    form_fetch_and_show("challenge-preference-form", "/pwncollege_api/v1/chall_pref", "POST", "Changes have been saved");
     $(".copy-button").click((event) => {
         let input = $(event.target).parents(".input-group").children("input")[0];
         input.select();

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -211,8 +211,8 @@
           <h2>Challenge Behavior</h2>
           <form method="post" id="challenge-preference-form">
             <div class="form-check">
-              <input class="form-check-input" type="checkbox" role="switch" name="stop-on-logout" id="stop-on-logout"{% if chall_pref.stop_on_logout %} checked{% endif %}>
-              <label class="form-check-label" for="stop-on-logout">Stop challenge on logout</label>
+              <input class="form-check-input" type="checkbox" role="switch" name="stop_on_logout" id="stop_on_logout"{% if chall_pref.stop_on_logout %} checked{% endif %}>
+              <label class="form-check-label" for="stop_on_logout">Stop challenge on logout</label>
             </div>
             <input class="btn btn-md btn-primary btn-outlined" type="submit" value="Save Changes">
           </form>

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -210,11 +210,17 @@
         <div class="tab-pane fade" id="challenge-behavior" role="tabpanel">
           <h2>Challenge Behavior</h2>
           <form method="post" id="challenge-preference-form">
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" role="switch" name="stop_on_logout" id="stop_on_logout"{% if chall_pref.stop_on_logout %} checked{% endif %}>
-              <label class="form-check-label" for="stop_on_logout">Stop challenge on logout</label>
+            <div class="form-group">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" role="switch" name="stop_on_logout" id="stop_on_logout"{% if chall_pref.stop_on_logout %} checked{% endif %}>
+                <label class="form-check-label" for="stop_on_logout">Stop challenge on logout</label>
+              </div>
             </div>
-            <input class="btn btn-md btn-primary btn-outlined" type="submit" value="Save Changes">
+            <div id="challenge-preference-results" class="form-group">
+            </div>
+            <div class="form-group">
+                <input class="btn btn-md btn-primary btn-outlined" type="submit" value="Save Changes">
+            </div>
           </form>
         </div>
 

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -17,6 +17,7 @@
         {% endif %}
 	      <a class="nav-link" id="settings-tokens-tab" data-toggle="pill" href="#tokens" role="tab">Access Tokens</a>
         <a class="nav-link" id="settings-reset-home-tab" data-toggle="pill" href="#reset-home" role="tab">Reset Home</a>
+        <a class="nav-link" id="settings-challenge-behavior-tab" data-toggle="pill" href="#challenge-behavior" role="tab">Challenge Behavior</a>
       </div>
     </div>
     <div class="col-md-8">
@@ -204,6 +205,14 @@
           </div>
           <br>
           <div id="reset-home-results" class="form-group"></div>
+        </div>
+
+        <div class="tab-pane fade" id="challenge-behavior" role="tabpanel">
+          <h2>Challenge Behavior</h2>
+          <div class="form-check form-switch">
+            <label class="form-check-label" for="stopChallengeOnLogoutSwitch">Stop challenge on logout</label>
+            <input class="form-check-input" type="checkbox" role="switch" id="stopChallengeOnLogoutSwitch">
+          </div>
         </div>
 
       </div>

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -209,10 +209,13 @@
 
         <div class="tab-pane fade" id="challenge-behavior" role="tabpanel">
           <h2>Challenge Behavior</h2>
-          <div class="form-check">
-              <input class="form-check-input" type="checkbox" role="switch" id="stopChallengeOnLogoutSwitch"{% if chall_pref.stop_on_logout %} checked{% endif %}>
-            <label class="form-check-label" for="stopChallengeOnLogoutSwitch">Stop challenge on logout</label>
-          </div>
+          <form method="post" id="challenge-preference-form">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" role="switch" name="stop-on-logout" id="stop-on-logout"{% if chall_pref.stop_on_logout %} checked{% endif %}>
+              <label class="form-check-label" for="stop-on-logout">Stop challenge on logout</label>
+            </div>
+            <input class="btn btn-md btn-primary btn-outlined" type="submit" value="Save Changes">
+          </form>
         </div>
 
       </div>

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -209,9 +209,9 @@
 
         <div class="tab-pane fade" id="challenge-behavior" role="tabpanel">
           <h2>Challenge Behavior</h2>
-          <div class="form-check form-switch">
-            <label class="form-check-label" for="stopChallengeOnLogoutSwitch">Stop challenge on logout</label>
+          <div class="form-check">
             <input class="form-check-input" type="checkbox" role="switch" id="stopChallengeOnLogoutSwitch">
+            <label class="form-check-label" for="stopChallengeOnLogoutSwitch">Stop challenge on logout</label>
           </div>
         </div>
 

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -210,7 +210,7 @@
         <div class="tab-pane fade" id="challenge-behavior" role="tabpanel">
           <h2>Challenge Behavior</h2>
           <div class="form-check">
-            <input class="form-check-input" type="checkbox" role="switch" id="stopChallengeOnLogoutSwitch">
+              <input class="form-check-input" type="checkbox" role="switch" id="stopChallengeOnLogoutSwitch"{% if chall_pref.stop_on_logout %} checked{% endif %}>
             <label class="form-check-label" for="stopChallengeOnLogoutSwitch">Stop challenge on logout</label>
           </div>
         </div>


### PR DESCRIPTION
Adds the ability to kill your container upon logging out.

Adds a settings option that allows users to keep their containers running after logout. Defaults to false.

Closes #22 