### PR TITLE
Feature/pull legacy on start

### DIFF
--- a/dojo_plugin/scripts/pull_images.py
+++ b/dojo_plugin/scripts/pull_images.py
@@ -11,7 +11,7 @@ logger.setLevel(logging.INFO)
 
 
 for image, in DojoChallenges.query.with_entities(db.distinct(DojoChallenges.data["image"])).all():
-    if not image or image.startswith("mac:") or image.startswith("pwncollege-"):
+    if not image or image.startswith("mac:"):
         continue
 
     for client in all_docker_clients():

--- a/dojo_plugin/scripts/pull_images.py
+++ b/dojo_plugin/scripts/pull_images.py
@@ -11,7 +11,7 @@ logger.setLevel(logging.INFO)
 
 
 for image, in DojoChallenges.query.with_entities(db.distinct(DojoChallenges.data["image"])).all():
-    if not image or image.startswith("mac:"):
+    if not image or image.startswith("mac:") or image.startswith("pwncollege-"):
         continue
 
     for client in all_docker_clients():

--- a/dojo_plugin/scripts/pull_images.py
+++ b/dojo_plugin/scripts/pull_images.py
@@ -4,16 +4,13 @@ import docker
 
 from ..utils import all_docker_clients
 from ..config import DOCKER_USERNAME, DOCKER_TOKEN
-
+from ..models import DojoChallenges
+from CTFd.models import db
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-
-for image, in DojoChallenges.query.with_entities(db.distinct(DojoChallenges.data["image"])).all():
-    if not image or image.startswith("mac:") or image.startswith("pwncollege-"):
-        continue
-
+def pull_on_all(image):
     for client in all_docker_clients():
         if DOCKER_USERNAME and DOCKER_TOKEN:
             client.login(DOCKER_USERNAME, DOCKER_TOKEN)
@@ -24,3 +21,11 @@ for image, in DojoChallenges.query.with_entities(db.distinct(DojoChallenges.data
             logger.error(f"... image not found: {image} on {client.api.base_url}...")
         except Exception as e:
             logger.error(f"... error: {image} on {client.api.base_url}...", exc_info=e)
+
+pull_on_all("pwncollege/challenge-legacy")
+
+for image, in DojoChallenges.query.with_entities(db.distinct(DojoChallenges.data["image"])).all():
+    if not image or image.startswith("mac:") or image.startswith("pwncollege-"):
+        continue
+
+    pull_on_all(image)


### PR DESCRIPTION
Updates the image puller script to always attempt to pull `pwncollege/challenge-legacy`. I believe it hasn't been pulling do to a bug in how that script retrieves the list of images.

Currently, staging does not have pwncollege/challenge-legacy pulled. It's been several hours since the last deployment. We'll know this works if, after merging this pull into dev, the docker images begin working after about 5 minutes (it takes a while to pull `pwncollege/challenge-legacy`.